### PR TITLE
Avoids checking out the PR if BUILDKITE_PULL_REQUEST is 'false'

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -n "${BUILDKITE_PULL_REQUEST}" ]] ; then
+if [[ -n "${BUILDKITE_PULL_REQUEST}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] ; then
   echo "--- Checking out merge ref for PR ${BUILDKITE_PULL_REQUEST}"
   git fetch origin "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
   git checkout FETCH_HEAD

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -33,3 +33,15 @@ checkout_hook="$PWD/hooks/checkout"
   refute_output --partial "GIT_CHECKED_OUT_FETCH_HEAD"
   assert_output --partial "No BUILDKITE_PULL_REQUEST variable set"
 }
+
+@test "Does nothing if no PR variable is false" {
+  export -f git
+  export BUILDKITE_PULL_REQUEST="false"
+
+  run "$checkout_hook"
+
+  assert_success
+  refute_output --partial "GIT_FETCHED"
+  refute_output --partial "GIT_CHECKED_OUT_FETCH_HEAD"
+  assert_output --partial "No BUILDKITE_PULL_REQUEST variable set"
+}


### PR DESCRIPTION
`BUILDKITE_PULL_REQUEST` is set to false when it's not a PR (rather than not at all, or empty)